### PR TITLE
Device refactor, fix plasma bug, GUI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,27 @@ Tutorials on YouTube!
 - Tutorial 5: (new!) <a href="https://www.youtube.com/watch?v=4njswvog4bo">FDTD</a>
 
 ---
-### Latest release: 2025.0
+### Latest release: 2025.1
 Windows: [Download .zip](https://github.com/NickKarpowicz/LightwaveExplorer/releases/latest/download/LightwaveExplorerWin64.zip)
 
 Mac: [Download .dmg](https://github.com/NickKarpowicz/LightwaveExplorer/releases/latest/download/LightwaveExplorerMacOS.dmg) (Intel native or Rosetta on Apple silicon) or [compile it yourself](#compiling-on-mac) (Apple silicon native) 
 
 Linux: [Get it on Flathub!](https://flathub.org/apps/io.github.NickKarpowicz.LightwaveExplorer)
 
-Changes in this version:
+Changes in 2025.1:
+- Fixed a bug introduced in 2025.0 where on CUDA the plasma would not affect fields in the y-direction
+- Fixed a bug where cancelling a batch job caused the subsequent batch to cancel itself
+- Axes and scales are now shown on the space and momentum images, and they're also saved when an SVG is produced.
+- Plot font size scaling works better with high-DPI displays
+- Refactored device structures to more efficiently and consistently allocate memory
+
+Changes in 2025.0:
 
  - FDTD mode is more accessible: besides the options for crystals in the Propagation pulldown menu, you can also load a custom grid containing different nonlinear materials at different positions using the fdtd() function
  - FDTD reflection mode for nonlinear reflection from a surface, using the fdtdReflection() sequence command.
  - Improved convergence for the nonlinear absorption/plasma response. Note that the changes I made here will re-scale the values of the nonlinear absorption parameter (now they are consistent with what was in the paper). The conversion factor for older values is $\left(\frac{1}{2\pi\epsilon_0}\right)^{\frac{1}{N_p-1}}$ where $N_p$ is the number of photons in the multiphoton transition (divide the old value by this number).
 
-  
+
 ---
 
 

--- a/Source/BuildResources/io.github.NickKarpowicz.LightwaveExplorer.metainfo.xml
+++ b/Source/BuildResources/io.github.NickKarpowicz.LightwaveExplorer.metainfo.xml
@@ -11,6 +11,18 @@
   <project_license>MIT</project_license>
   <content_rating type="oars-1.1" />
   <releases>
+  <release version="2025.1" date="2025-02-17" urgency="high">
+  <description>
+  <p>Changes in this version:</p>
+  <ul>
+  <li>Fixed a bug introduced in 2025.0 where on CUDA the plasma would not affect fields in the y-direction</li>
+  <li>Fixed a bug where cancelling a batch job caused the subsequent batch to cancel itself</li>
+  <li>Axes and scales are now shown on the space and momentum images, and they're also saved when an SVG is produced.</li>
+  <li>Plot font size scaling works better with high-DPI displays</li>
+  <li>Refactored device structures to more efficiently and consistently allocate memory</li>
+  </ul>
+  </description>
+  </release>
   <release version="2025.0" date="2025-02-08" urgency="high">
   <description>
   <p>Changes in this version:</p>

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -274,9 +274,7 @@ class LWEDevice{
     public:
     simulationParameterSet* cParams;
 	int memoryStatus = -1;
-	bool hasPlasma = false;
 	bool configuredFFT = false;
-	bool isCylindric = false;
     virtual int deviceCalloc(void** ptr, size_t N, size_t elementSize) = 0;
     virtual void deviceMemset(void* ptr, int value, size_t count) = 0;
     virtual void deviceMemcpy(

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -269,7 +269,6 @@ class NonlinearPropertyFlags{
     bool assumeCentrosymmetric = false;
 };
 
-
 class LWEDevice{
     public:
     simulationParameterSet* cParams;
@@ -306,7 +305,7 @@ public:
     {
         int error = d->deviceCalloc((void**)&buffer, count, elementSize);
         if(error){
-            throw std::runtime_error("Allocation of LWE buffer failed with error");
+            throw std::runtime_error("Couldn't allocate enough memory.");
         }
     }
     LWEBuffer(LWEDevice* d, const std::vector<T> v) : 
@@ -315,7 +314,7 @@ public:
     bytes(count * sizeof(T)){
         int error = d->deviceCalloc((void**)&buffer, count, sizeof(T));
         if(error){
-            throw std::runtime_error("Allocation of LWE buffer failed with error");
+            throw std::runtime_error("Couldn't allocate enough memory.");
         }
         d->deviceMemcpy(buffer, v.data(), count, copyType::ToDevice);
     }

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -264,6 +264,21 @@ class NonlinearPropertyFlags{
     bool hasChi3 = false;
     bool assumeCentrosymmetric = false;
 };
+
+class LWEDevice{
+    public:
+    virtual int deviceCalloc(void** ptr, size_t N, size_t elementSize) = 0;
+    virtual void deviceMemset(void* ptr, int value, size_t count) = 0;
+    virtual void deviceMemcpy(
+		void* dst, 
+		const void* src, 
+		size_t count, 
+		copyType kind) = 0;
+    virtual void deviceFree(void* block) = 0;
+    virtual void fft(const void* input, void* output, deviceFFT type) = 0;
+    virtual void fftInitialize() = 0;
+};
+
 //class holding the device data structures
 //note that it uses c-style arrays-- this is for compatibility
 //with all of the platforms involved, and because it is transferred

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -283,17 +283,17 @@ class LWEDevice{
 template<typename T>
 class LWEBuffer{
     LWEDevice* d = nullptr;
-    size_t count = 0;
-    size_t bytes = 0;
+
 public:
     T* buffer = nullptr;
-
+    size_t count = 0;
+    size_t bytes = 0;
     LWEBuffer(){}
     LWEBuffer(const LWEBuffer&) = delete;
     LWEBuffer(LWEDevice* d, const size_t N, const size_t elementSize) : 
     d(d),
-    count(N),
-    bytes(N*elementSize)
+    count(maxN(N,1)),
+    bytes(count*elementSize)
     {
         int error = d->deviceCalloc((void**)&buffer, count, elementSize);
         if(error){
@@ -317,6 +317,10 @@ public:
     T* device_ptr() const {
         if(bytes == 0) throw std::runtime_error("Attempted to access empty LWEBuffer");
         return buffer;
+    }
+
+    void initialize_to_zero(){
+        if(bytes) d->deviceMemset(buffer, 0, bytes);
     }
 };
 

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -283,8 +283,6 @@ class LWEDevice{
 		copyType kind) = 0;
     virtual void deviceFree(void* block) = 0;
     virtual void fft(const void* input, void* output, deviceFFT type) = 0;
-    virtual void fftInitialize() = 0;
-    virtual void fftDestroy() = 0;
 
     void deviceMemcpy(
 		void* dst, 
@@ -389,7 +387,7 @@ public:
     LWEBuffer& operator=(const LWEBuffer&) = delete;
     LWEBuffer(LWEDevice* d, const size_t N, const size_t elementSize) : 
     d(d),
-    count(maxN(N,1)),
+    count(maxN(N,static_cast<size_t>(1))),
     bytes(count*elementSize)
     {
         int error = d->deviceCalloc((void**)&buffer, count, elementSize);

--- a/Source/DataStructures.hpp
+++ b/Source/DataStructures.hpp
@@ -283,7 +283,8 @@ class LWEDevice{
 		copyType kind) = 0;
     virtual void deviceFree(void* block) = 0;
     virtual void fft(const void* input, void* output, deviceFFT type) = 0;
-
+    virtual void reset(simulationParameterSet* sCPU) = 0;
+    
     void deviceMemcpy(
 		void* dst, 
 		const void* src, 

--- a/Source/Devices/LWEAciveDeviceCounter.h
+++ b/Source/Devices/LWEAciveDeviceCounter.h
@@ -61,71 +61,34 @@ int hardwareCheck(int* CUDAdeviceCount) {
 }
 
 template <typename deviceFP, typename deviceComplex>
-class counterDevice {
+class counterDevice : public LWEDevice {
 private:
-	bool configuredFFT = 0;
-	bool isCylindric = 0;
 	deviceParameterSet<deviceFP, deviceComplex> dParamslocal;
-	void fftDestroy() {
-	}
-
 public:
-	int stream;
-	int memoryStatus;
-	bool hasPlasma;
 	deviceParameterSet<deviceFP, deviceComplex> deviceStruct;
 	deviceParameterSet<deviceFP, deviceComplex>* s;
-	simulationParameterSet* cParams;
 	deviceParameterSet<deviceFP, deviceComplex>* dParamsDevice;
 	counterDevice(simulationParameterSet* sCPU) {
 		s = &deviceStruct;
 		memoryStatus = 0;
-		stream = 0;
-		configuredFFT = 0;
-		isCylindric = 0;
+		configuredFFT = true;
 		cParams = sCPU;
 		dParamsDevice = &dParamslocal;
 		sCPU->initializeDeviceParameters(s);
-		hasPlasma = s->hasPlasma;
-	}
-
-	~counterDevice() {
 	}
 	template<typename T>
-	void deviceLaunch(const unsigned int Nblock, const unsigned int Nthread, T functor) {
-	}
+	void deviceLaunch(const unsigned int Nblock, const unsigned int Nthread, T functor) {}
 
-	int deviceCalloc(void** ptr, const int64_t N, const int64_t elementSize) {
-		return 0;
-	}
-
-	void deviceMemset(void* ptr, const int value, const int64_t count) {
-	}
-
-	void deviceMemcpy(void* dst, const void* src, const int64_t count, const copyType kind) {
-	}
-
-	void deviceFree(const void* block) {
-	}
-
+	int deviceCalloc(void** ptr, const size_t N, const size_t elementSize) override {return 0;}
+	void deviceMemset(void* ptr, int value, size_t count) override {}
+	void deviceMemcpyImplementation(void* dst, const void* src, size_t count, copyType kind) override {}
+	void deviceFree(void* block) override {}
+	void fft(const void* input, void* output, deviceFFT type) override {}
 	bool isTheCanaryPixelNaN(const deviceFP* canaryPointer) {
 		return false;
 	}
 
-	void fft(const void* input, const void* output, const deviceFFT type) {
-	}
-
-	void fftInitialize() {
-		hasPlasma = (*s).hasPlasma;
-		configuredFFT = 1;
-	}
-	void deallocateSet() {
-	}
 	void reset(simulationParameterSet* sCPU) {
 		sCPU->initializeDeviceParameters(s);
-		hasPlasma = s->hasPlasma;
-	}
-	int allocateSet(simulationParameterSet* sCPU) {
-		return 0;
 	}
 };

--- a/Source/Devices/LWEAciveDeviceCounter.h
+++ b/Source/Devices/LWEAciveDeviceCounter.h
@@ -88,7 +88,7 @@ public:
 		return false;
 	}
 
-	void reset(simulationParameterSet* sCPU) {
+	void reset(simulationParameterSet* sCPU) override {
 		sCPU->initializeDeviceParameters(s);
 	}
 };

--- a/Source/Devices/LWEActiveDeviceCPU.h
+++ b/Source/Devices/LWEActiveDeviceCPU.h
@@ -535,16 +535,20 @@ public:
 		configuredFFT = true;
 	}
 
-	void reset(simulationParameterSet* sCPU) {
+	void reset(simulationParameterSet* sCPU) override {
+		bool resetFFT = (s->hasPlasma != sCPU->hasPlasma());
 		allocation->useNewParameterSet(sCPU);
+		if(resetFFT){
+			fftInitialize();
+		}
 	#if defined _WIN32 || defined __linux__
 		if(indices.size() < static_cast<std::size_t>(4 * (*s).NgridC)){
 			indices = std::vector<int64_t>(4 * (*s).NgridC);
 			std::iota(indices.begin(), indices.end(), 0);
 		}
 	#endif
-		
 	}
+
 	int allocateSet(simulationParameterSet* sCPU) {
 		cParams = sCPU;
 		if(memoryStatus == 0) allocation = nullptr;

--- a/Source/Devices/LWEActiveDeviceCPU.h
+++ b/Source/Devices/LWEActiveDeviceCPU.h
@@ -162,27 +162,23 @@ namespace deviceLibCPUFP32{
 }
 
 template <typename deviceFP, typename deviceComplex>
-class CPUDevice {
+class CPUDevice : public LWEDevice {
 private:
 #ifdef __APPLE__
 	dispatch_queue_t queue{};
 #elif defined _WIN32 || defined __linux__
 	std::vector<int64_t> indices;
 #endif
-	bool configuredFFT = false;
-	bool isCylindric = false;
-	deviceFP canaryPixel = 0.0;
-	deviceParameterSet<deviceFP, deviceComplex> dParamslocal;
-	fftw_plan fftPlanD2Z;
-	fftw_plan fftPlanZ2D;
-	fftw_plan fftPlan1DD2Z;
-	fftw_plan fftPlan1DZ2D;
-	fftw_plan doublePolfftPlan;
-	fftwf_plan fftPlanD2Z32;
-	fftwf_plan fftPlanZ2D32;
-	fftwf_plan fftPlan1DD2Z32;
-	fftwf_plan fftPlan1DZ2D32;
-	fftwf_plan doublePolfftPlan32;
+	fftw_plan fftPlanD2Z = {};
+	fftw_plan fftPlanZ2D = {};
+	fftw_plan fftPlan1DD2Z = {};
+	fftw_plan fftPlan1DZ2D = {};
+	fftw_plan doublePolfftPlan = {};
+	fftwf_plan fftPlanD2Z32 = {};
+	fftwf_plan fftPlanZ2D32 = {};
+	fftwf_plan fftPlan1DD2Z32 = {};
+	fftwf_plan fftPlan1DZ2D32 = {};
+	fftwf_plan doublePolfftPlan32 = {};
 	
 	void fftDestroy() {
 		if(sizeof(deviceFP)==sizeof(double)){
@@ -190,42 +186,26 @@ private:
 			fftw_destroy_plan(fftPlanZ2D);
 			fftw_destroy_plan(fftPlan1DD2Z);
 			fftw_destroy_plan(fftPlan1DZ2D);
-			if (isCylindric)fftw_destroy_plan(doublePolfftPlan);
+			if (s->isCylindric)fftw_destroy_plan(doublePolfftPlan);
 		}
 		else{
 			fftwf_destroy_plan(fftPlanD2Z32);
 			fftwf_destroy_plan(fftPlanZ2D32);
 			fftwf_destroy_plan(fftPlan1DD2Z32);
 			fftwf_destroy_plan(fftPlan1DZ2D32);
-			if (isCylindric)fftwf_destroy_plan(doublePolfftPlan32);
+			if (s->isCylindric)fftwf_destroy_plan(doublePolfftPlan32);
 		}
 		fftw_cleanup();
 	}
 
 public:
-	int stream;
-	int memoryStatus;
-	bool hasPlasma = false;
-	deviceParameterSet<deviceFP, deviceComplex> deviceStruct;
 	deviceParameterSet<deviceFP, deviceComplex>* s;
-	simulationParameterSet* cParams;
 	deviceParameterSet<deviceFP, deviceComplex>* dParamsDevice;
-
+	std::unique_ptr<UPPEAllocation<deviceFP, deviceComplex>> allocation;
+	using LWEDevice::deviceMemcpy;
 	CPUDevice(simulationParameterSet* sCPU) {
-		s = &deviceStruct;
-		memoryStatus = -1;
-		stream = 0;
-		cParams = NULL;
-		dParamsDevice = NULL;
-		configuredFFT = 0;
-		isCylindric = 0;
-		fftPlanD2Z = 0;
-		fftPlanZ2D = 0;
-		fftPlan1DD2Z = 0;
-		fftPlan1DZ2D = 0;
-		doublePolfftPlan = 0;
-		dParamsDevice = &dParamslocal;
 		memoryStatus = allocateSet(sCPU);
+		s = &(allocation->parameterSet);
 	#ifdef __APPLE__
 		queue = dispatch_queue_create("Kernel", DISPATCH_QUEUE_CONCURRENT);
 	#endif
@@ -233,7 +213,6 @@ public:
 
 	~CPUDevice() {
 		fftDestroy();
-		deallocateSet();
 	}
 
 	//Use different threading models on different platforms:
@@ -276,65 +255,18 @@ public:
 		}
 	}
 #endif
-	int deviceCalloc(void** ptr, const size_t N, const size_t elementSize){
+	int deviceCalloc(void** ptr, const size_t N, const size_t elementSize) override {
 		*ptr = calloc(N, elementSize);
 		return static_cast<int>(*ptr == nullptr);
 	}
-	void deviceMemset(void* ptr, int value, size_t count){
+	void deviceMemset(void* ptr, int value, size_t count) override {
 		memset(ptr, value, count);
 	}
-	template <typename T>
-	void deviceMemcpy(
-		T* dst, 
-		const T* src, 
-		size_t count, 
-		copyType kind) {
+	void deviceMemcpyImplementation(void* dst, const void* src, size_t count, copyType kind) override {
 		std::memcpy(dst, src, count);
 	}
-	void deviceMemcpy(
-		double* dst, 
-		const float* src, 
-		size_t count, 
-		copyType kind) {
-		for (size_t i = 0; i < count / sizeof(double); i++) {
-			dst[i] = static_cast<double>(src[i]);
-		}
-	}
-	void deviceMemcpy(
-		std::complex<double>* dst, 
-		const std::complex<float>* src, 
-		size_t count, 
-		copyType kind) {
-		for (size_t i = 0; i < count / sizeof(std::complex<double>); i++) {
-			dst[i] = std::complex<double>(
-				static_cast<double>(src[i].real()), 
-				static_cast<double>(src[i].imag()));
-		}
-	}
 
-	void deviceMemcpy(
-		std::complex<float>* dst, 
-		const std::complex<double>* src, 
-		size_t count, 
-		copyType kind) {
-		for (size_t i = 0; i < count / sizeof(std::complex<double>); i++) {
-			dst[i] = std::complex<float>(
-				static_cast<float>(src[i].real()), 
-				static_cast<float>(src[i].imag()));
-		}
-	}
-
-	void deviceMemcpy(
-		float* dst, 
-		const double* src, 
-		size_t count, 
-		copyType kind) {
-		for (size_t i = 0; i < count / sizeof(double); i++) {
-			dst[i] = static_cast<float>(src[i]);
-		}
-	}
-
-	void deviceFree(void* block){
+	void deviceFree(void* block) override {
 		free(block);
 	}
 
@@ -342,7 +274,7 @@ public:
 		return isnan(*canaryPointer);
 	}
 	
-	void fft(void* input, void* output, deviceFFT type) const {
+	void fft(const void* input, void* output, deviceFFT type) override {
 		if (!configuredFFT) return;
 		if(sizeof(deviceFP) == sizeof(double)){
 			switch (type){
@@ -386,8 +318,6 @@ public:
 
 	void fftInitialize() {
 		if (configuredFFT) fftDestroy();
-		isCylindric = (*s).isCylindric;
-		hasPlasma = (*s).hasPlasma;
 		if (sizeof(deviceFP) == sizeof(double)) {
 			std::vector<double> setupWorkD((*s).Ngrid * (2 + 2 * (*s).isCylindric));
 			std::vector<std::complex<double>> setupWorkC((*s).NgridC * (2 + 2 * (*s).isCylindric));
@@ -599,157 +529,33 @@ public:
 			}
 		}
 		else{
-			configuredFFT = 0;
+			configuredFFT = false;
 			return;
 		}
-		configuredFFT = 1;
+		configuredFFT = true;
 	}
-	void deallocateSet() {
-		deviceFree((*s).gridETime1);
-		deviceFree((*s).workspace1);
-		deviceFree((*s).gridEFrequency1);
-		deviceFree((*s).gridPropagationFactor1);
-		deviceFree((*s).gridBiaxialDelta);
-		if ((*s).isCylindric) {
-			deviceFree((*s).gridPropagationFactor1Rho1);
-			deviceFree((*s).gridRadialLaplacian1);
-		}
-		deviceFree((*s).gridPolarizationFactor1);
-		deviceFree((*s).gridEFrequency1Next1);
-		deviceFree((*s).k1);
-		deviceFree((*s).gridPolarizationTime1);
-		deviceFree((*s).expGammaT);
-		deviceFree((*s).chiLinear1);
-		deviceFree((*s).fieldFactor1);
-		deviceFree((*s).inverseChiLinear1);
-	}
+
 	void reset(simulationParameterSet* sCPU) {
-		if((*s).hasPlasma != ((*sCPU).nonlinearAbsorptionStrength != 0.0)){
-			deallocateSet();
-			memoryStatus = allocateSet(sCPU);
-		}
-		else{
-			sCPU->initializeDeviceParameters(s);
-			hasPlasma = s->hasPlasma;
-		}
+		allocation->useNewParameterSet(sCPU);
 	#if defined _WIN32 || defined __linux__
-		indices = std::vector<int64_t>(4 * (*s).NgridC);
-		std::iota(indices.begin(), indices.end(), 0);
+		if(indices.size() < static_cast<std::size_t>(4 * (*s).NgridC)){
+			indices = std::vector<int64_t>(4 * (*s).NgridC);
+			std::iota(indices.begin(), indices.end(), 0);
+		}
 	#endif
-		sCPU->fillRotationMatricies(s);
-		int64_t beamExpansionFactor = 1;
-		if ((*s).isCylindric) {
-			beamExpansionFactor = 2;
-			if ((*s).hasPlasma) beamExpansionFactor = 4;
-		}
-		deviceMemset((*s).gridETime1, 0, 2 * (*s).Ngrid * sizeof(deviceFP));
-		deviceMemset((*s).gridPolarizationTime1, 0, 2 * (*s).Ngrid * sizeof(deviceFP));
-		deviceMemset(
-			(*s).workspace1, 0, 
-			beamExpansionFactor * 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).gridEFrequency1, 0, 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).gridPropagationFactor1, 0, 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).gridPolarizationFactor1, 0, 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).gridEFrequency1Next1, 0, 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).k1, 0, 2 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-
-		//cylindric sym grids
-		if ((*s).isCylindric) {
-			deviceMemset((*s).gridPropagationFactor1Rho1, 0, 4 * (*s).NgridC * sizeof(std::complex<deviceFP>));
-			deviceMemset((*s).gridRadialLaplacian1, 0, 
-				2 * beamExpansionFactor * (*s).Ngrid * sizeof(std::complex<deviceFP>));
-		}
-
-		//smaller helper grids
-		deviceMemset((*s).expGammaT, 0, 2 * (*s).Ntime * sizeof(deviceFP));
-		deviceMemset((*s).chiLinear1, 0, 2 * (*s).Nfreq * sizeof(std::complex<deviceFP>));
-		deviceMemset((*s).fieldFactor1, 0, 2 * (*s).Nfreq * sizeof(deviceFP));
-		deviceMemset((*s).inverseChiLinear1, 0, 2 * (*s).Nfreq * sizeof(deviceFP));
-
-		std::vector<double> expGammaTCPU(2 * (*s).Ntime);
-		for (int64_t i = 0; i < (*s).Ntime; ++i) {
-			expGammaTCPU[i] = exp((*s).dt * i * (*sCPU).drudeGamma);
-			expGammaTCPU[i + (*s).Ntime] = exp(-(*s).dt * i * (*sCPU).drudeGamma);
-		}
-		deviceMemcpy((*s).expGammaT, expGammaTCPU.data(), 2 * sizeof(double) * (*s).Ntime, copyType::ToDevice);
-
-		sCPU->finishConfiguration(s);
-		deviceMemcpy(dParamsDevice, s, sizeof(deviceParameterSet<deviceFP, deviceComplex>), copyType::ToDevice);
+		
 	}
 	int allocateSet(simulationParameterSet* sCPU) {
 		cParams = sCPU;
-		sCPU->initializeDeviceParameters(s);
-		hasPlasma = s->hasPlasma;
+		if(memoryStatus == 0) allocation = nullptr;
+		allocation = std::make_unique<UPPEAllocation<deviceFP, deviceComplex>>(this, sCPU);
+		s = &(allocation->parameterSet);
 		fftInitialize();
-
-		int memErrors = 0;
-
-
-	#if defined _WIN32 || defined __linux__
-		indices = std::vector<int64_t>(4 * (*s).NgridC);
-		std::iota(indices.begin(), indices.end(), 0);
-	#endif
-
-		int64_t beamExpansionFactor = 1;
-		if ((*s).isCylindric) {
-			beamExpansionFactor = 2;
-			if ((*s).hasPlasma) beamExpansionFactor = 4;
-		}
-		sCPU->fillRotationMatricies(s);
-		//GPU allocations
-		//
-		// currently 8 large grids, meaning memory use is approximately
-		// 64 bytes per grid point (8 grids x 2 polarizations x 4ouble precision)
-		// plus a little bit for additional constants/workspaces/etc
-		memErrors += deviceCalloc((void**)
-			&(*s).gridETime1, 2 * (*s).Ngrid, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPolarizationTime1, 2 * (*s).Ngrid, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).workspace1, beamExpansionFactor * 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridEFrequency1, 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPropagationFactor1, 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPolarizationFactor1, 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridEFrequency1Next1, 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).k1, 2 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridBiaxialDelta, (*s).NgridC, sizeof(deviceFP));
-		//cylindric sym grids
-		if ((*s).isCylindric) {
-			memErrors += deviceCalloc((void**)
-				&(*s).gridPropagationFactor1Rho1, 4 * (*s).NgridC, sizeof(std::complex<deviceFP>));
-			memErrors += deviceCalloc((void**)
-				&(*s).gridRadialLaplacian1, 
-				2 * beamExpansionFactor * (*s).Ngrid, sizeof(std::complex<deviceFP>));
-		}
-
-		//smaller helper grids
-		memErrors += deviceCalloc((void**)
-			&(*s).expGammaT, 2 * (*s).Ntime, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).chiLinear1, 2 * (*s).Nfreq, sizeof(std::complex<deviceFP>));
-		memErrors += deviceCalloc((void**)
-			&(*s).fieldFactor1, 2 * (*s).Nfreq, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).inverseChiLinear1, 2 * (*s).Nfreq, sizeof(deviceFP));
-		std::vector<double> expGammaTCPU(2 * (*s).Ntime);
-		for (int64_t i = 0; i < (*s).Ntime; ++i) {
-			expGammaTCPU[i] = exp((*s).dt * i * (*sCPU).drudeGamma);
-			expGammaTCPU[i + (*s).Ntime] = exp(-(*s).dt * i * (*sCPU).drudeGamma);
-		}
-		deviceMemcpy((*s).expGammaT, expGammaTCPU.data(), 2 * sizeof(double) * (*s).Ntime, copyType::ToDevice);
-
-		(*sCPU).memoryError = memErrors;
-		if (memErrors > 0) {
-			return memErrors;
-		}
-		sCPU->finishConfiguration(s);
-		deviceMemcpy(dParamsDevice, s, sizeof(deviceParameterSet<deviceFP, deviceComplex>), copyType::ToDevice);
+		dParamsDevice = allocation->parameterSet_deviceCopy.device_ptr();
+		#if defined _WIN32 || defined __linux__
+			indices = std::vector<int64_t>(4 * (*s).NgridC);
+			std::iota(indices.begin(), indices.end(), 0);
+		#endif
 		return 0;
 	}
 };

--- a/Source/Devices/LWEActiveDeviceCUDA.cuh
+++ b/Source/Devices/LWEActiveDeviceCUDA.cuh
@@ -329,7 +329,7 @@ public:
 		}
 		cufftSetStream(fftPlanD2Z, stream);
 		cufftSetStream(fftPlanZ2D, stream);
-		configuredFFT = 1;
+		configuredFFT = true;
 	}
 
 	void fft(const void* input, void* output, deviceFFT type) override {

--- a/Source/Devices/LWEActiveDeviceCUDA.cuh
+++ b/Source/Devices/LWEActiveDeviceCUDA.cuh
@@ -157,7 +157,7 @@ private:
 	cufftHandle fftPlan1DZ2D;
 	cufftHandle doublePolfftPlan;
 
-	void fftDestroy() override {
+	void fftDestroy() {
 		cufftDestroy(fftPlanD2Z);
 		cufftDestroy(fftPlanZ2D);
 		cufftDestroy(fftPlan1DD2Z);
@@ -232,7 +232,7 @@ public:
 		cudaFree(block);
 	}
 
-	void fftInitialize() override {
+	void fftInitialize() {
 		if (configuredFFT) {
 			fftDestroy();
 		}

--- a/Source/Devices/LWEActiveDeviceCUDA.cuh
+++ b/Source/Devices/LWEActiveDeviceCUDA.cuh
@@ -321,8 +321,12 @@ public:
 		}
 	}
 
-	void reset(simulationParameterSet* sCPU) {
+	void reset(simulationParameterSet* sCPU) override {
+		bool resetFFT = (s->hasPlasma != sCPU->hasPlasma());
 		allocation->useNewParameterSet(sCPU);
+		if(resetFFT){
+			fftInitialize();
+		}
 	}
 	int allocateSet(simulationParameterSet* sCPU) {
 		cParams = sCPU;

--- a/Source/Devices/LWEActiveDeviceCUDA.cuh
+++ b/Source/Devices/LWEActiveDeviceCUDA.cuh
@@ -148,7 +148,7 @@ __global__ static void deviceLaunchFunctorWrapper(const T functor) {
 }
 
 template<typename deviceFP, typename deviceComplex>
-class CUDADevice {
+class CUDADevice : public LWEDevice {
 private:
 	bool configuredFFT = false;
 	bool isCylindric = false;
@@ -247,20 +247,20 @@ public:
 	}
 
 
-	int deviceCalloc(void** ptr, size_t N, size_t elementSize) {
+	int deviceCalloc(void** ptr, size_t N, size_t elementSize) override {
 		int err = cudaMalloc(ptr, N * elementSize);
 		cudaMemset(*ptr, 0, N * elementSize);
 		return err;
 	}
 
-	void deviceMemset(void* ptr, int value, size_t count) {
+	void deviceMemset(void* ptr, int value, size_t count) override {
 		cudaMemset(ptr, value, count);
 	}
 	void deviceMemcpy(
 		void* dst, 
 		const void* src, 
 		size_t count, 
-		copyType kind) {
+		copyType kind) override {
 		cudaMemcpy(dst, src, count, static_cast<cudaMemcpyKind>(static_cast<int>(kind)));
 	}
 	void deviceMemcpy(
@@ -329,11 +329,11 @@ public:
 	}
 
 
-	void deviceFree(void* block) {
+	void deviceFree(void* block) override {
 		cudaFree(block);
 	}
 
-	void fftInitialize() {
+	void fftInitialize() override {
 		if (configuredFFT) {
 			fftDestroy();
 		}
@@ -383,7 +383,7 @@ public:
 		configuredFFT = 1;
 	}
 
-	void fft(const void* input, void* output, deviceFFT type) {
+	void fft(const void* input, void* output, deviceFFT type) override {
 		if(sizeof(deviceFP) == sizeof(double)){
 			switch (type){
 			case deviceFFT::D2Z:

--- a/Source/Devices/LWEActiveDeviceSYCL.h
+++ b/Source/Devices/LWEActiveDeviceSYCL.h
@@ -113,10 +113,8 @@ static constexpr float j0Device(const float x) {
 }
 
 template<typename deviceFP, typename deviceComplex>
-class SYCLDevice {
+class SYCLDevice : public LWEDevice {
 private:
-	bool configuredFFT = false;
-	bool isCylindric = false;
 	deviceFP canaryPixel = 0.0;
 	oneapi::mkl::dft::descriptor<dftPrecision, oneapi::mkl::dft::domain::REAL>* fftPlanD2Z;
 	oneapi::mkl::dft::descriptor<dftPrecision, oneapi::mkl::dft::domain::REAL>* fftPlan1DD2Z;
@@ -129,26 +127,18 @@ private:
 	}
 public:
 	sycl::queue stream;
-	deviceParameterSet<deviceFP, deviceComplex> deviceStruct;
 	deviceParameterSet<deviceFP, deviceComplex>* s;
 	deviceParameterSet<deviceFP, deviceComplex>* dParamsDevice;
-	simulationParameterSet* cParams;
-	int memoryStatus;
-	bool hasPlasma = false;
+	std::unique_ptr<UPPEAllocation<deviceFP, deviceComplex>> allocation;
 
 	SYCLDevice(simulationParameterSet* sCPU) {
-		memoryStatus = -1;
-		configuredFFT = 0;
-		isCylindric = 0;
-		s = &deviceStruct;
 		memoryStatus = allocateSet(sCPU);
+		s = &(allocation->parameterSet);
 	}
 
 	~SYCLDevice() {
 		stream.wait();
 		fftDestroy();
-		deallocateSet();
-		deviceFree(dParamsDevice);
 	}
 
 	bool isTheCanaryPixelNaN(const deviceFP* canaryPointer) {
@@ -166,7 +156,7 @@ public:
 			});
 }
 
-	int deviceCalloc(void** ptr, const int64_t N, const int64_t elementSize) {
+	int deviceCalloc(void** ptr, const size_t N, const size_t elementSize) override {
 		(*ptr) = sycl::aligned_alloc_device(
 			2 * sizeof(deviceFP), 
 			N * elementSize, 
@@ -177,86 +167,24 @@ public:
 		return 0;
 	}
 
-	void deviceMemset(void* ptr, int value, int64_t count) {
+	void deviceMemset(void* ptr, int value, size_t count) override {
 		stream.wait();
 		stream.memset(ptr, value, count);
 	}
 
-	void deviceMemcpy(
+	void deviceMemcpyImplementation(
 		void* dst, 
 		const void* src, 
-		const int64_t count, 
-		const copyType kind) {
+		const size_t count, 
+		const copyType kind) override {
 		stream.wait();
 		stream.memcpy(dst, src, count);
 		stream.wait();
 	}
 
-	void deviceMemcpy(
-		double* dst, 
-		const float* src, 
-		const int64_t count, 
-		const copyType kind) {
-		stream.wait();
-		float* copyBuffer = new float[count / sizeof(double)]();
-		stream.memcpy(copyBuffer, src, count/2);
-		stream.wait();
-		for (int64_t i = 0; i < count / sizeof(double); i++) {
-			dst[i] = static_cast<double>(copyBuffer[i]);
-		}
-		delete[] copyBuffer;
-	}
+	//TODO: deleted implementations waited for stream before memcpy - might have to add a wait function to some cases...
 
-	void deviceMemcpy(
-		std::complex<double>* dst, 
-		const sycl::ext::oneapi::experimental::complex<float>* src, 
-		int64_t count, 
-		copyType kind) {
-		stream.wait();
-		std::complex<float>* copyBuffer = new std::complex<float>[count / sizeof(std::complex<double>)]();
-		stream.memcpy(copyBuffer, src, count/2);
-		stream.wait();
-		for (int64_t i = 0; i < count / sizeof(std::complex<double>); i++) {
-			dst[i] = std::complex<double>(
-				static_cast<float>(copyBuffer[i].real()), 
-				static_cast<float>(copyBuffer[i].imag()));
-		}
-		delete[] copyBuffer;
-	}
-
-	void deviceMemcpy(
-		sycl::ext::oneapi::experimental::complex<float>* dst, 
-		const std::complex<double>* src, 
-		const int64_t count, 
-		const copyType kind) {
-		stream.wait();
-		std::complex<float>* copyBuffer = new std::complex<float>[count / sizeof(std::complex<double>)]();
-		for (int64_t i = 0; i < count / sizeof(std::complex<double>); i++) {
-			copyBuffer[i] = std::complex<float>(
-				static_cast<float>(src[i].real()), 
-				static_cast<float>(src[i].imag()));
-		}
-		stream.memcpy(dst, copyBuffer, count / 2);
-		stream.wait();
-		delete[] copyBuffer;
-	}
-
-	void deviceMemcpy(
-		float* dst, 
-		const double* src, 
-		const int64_t count, 
-		const copyType kind) {
-		stream.wait();
-		float* copyBuffer = new float[count / sizeof(double)]();
-		for (int64_t i = 0; i < count / sizeof(double); i++) {
-			copyBuffer[i] = static_cast<float>(src[i]);
-		}
-		stream.memcpy(dst, copyBuffer, count / 2);
-		stream.wait();
-		delete[] copyBuffer;
-	}
-
-	void deviceFree(void* block) {
+	void deviceFree(void* block) override {
 		stream.wait();
 		sycl::free(block, stream);
 	}
@@ -265,9 +193,6 @@ public:
 		if (configuredFFT) {
 			fftDestroy();
 		}
-		isCylindric = 0;
-		hasPlasma = (*s).hasPlasma;
-
 		fftPlan1DD2Z = 
 			new oneapi::mkl::dft::descriptor<dftPrecision, oneapi::mkl::dft::domain::REAL>((*s).Ntime);
 		fftPlan1DD2Z->set_value(
@@ -329,11 +254,11 @@ public:
 
 		fftPlan1DD2Z->commit(stream);
 		fftPlanD2Z->commit(stream);
-		if (isCylindric) doublePolfftPlan->commit(stream);
+		if (s->isCylindric) doublePolfftPlan->commit(stream);
 		configuredFFT = 1;
 	}
 
-	void fft(const void* input, void* output, const deviceFFT type) const {
+	void fft(const void* input, void* output, const deviceFFT type) override {
 		switch (type) {
 		case deviceFFT::D2Z:
 			oneapi::mkl::dft::compute_forward(*fftPlanD2Z, (deviceFP*)input, (std::complex<deviceFP>*)output);
@@ -352,81 +277,9 @@ public:
 			break;
 		}
 	}
-	void deallocateSet() {
-		stream.wait();
-		deviceFree((*s).gridETime1);
-		deviceFree((*s).workspace1);
-		deviceFree((*s).gridEFrequency1);
-		deviceFree((*s).gridPropagationFactor1);
-		deviceFree((*s).gridBiaxialDelta);
-		if ((*s).isCylindric) {
-			deviceFree((*s).gridPropagationFactor1Rho1);
-			deviceFree((*s).gridRadialLaplacian1);
-		}
-		deviceFree((*s).gridPolarizationFactor1);
-		deviceFree((*s).gridEFrequency1Next1);
-		deviceFree((*s).k1);
-		deviceFree((*s).gridPolarizationTime1);
-		deviceFree((*s).expGammaT);
-		deviceFree((*s).chiLinear1);
-		deviceFree((*s).fieldFactor1);
-		deviceFree((*s).inverseChiLinear1);
-	}
+
 	void reset(simulationParameterSet* sCPU) {
-		if((*s).hasPlasma != ((*sCPU).nonlinearAbsorptionStrength != 0.0)){
-			deallocateSet();
-			memoryStatus = allocateSet(sCPU);
-		}
-		else{
-			sCPU->initializeDeviceParameters(s);
-			hasPlasma = s->hasPlasma;
-		}
-		sCPU->fillRotationMatricies(s);
-		int64_t beamExpansionFactor = 1;
-		if ((*s).isCylindric) {
-			beamExpansionFactor = 2;
-			if ((*s).hasPlasma) beamExpansionFactor = 4;
-		}
-		deviceMemset((*s).gridETime1, 0, 2 * (*s).Ngrid * sizeof(deviceFP));
-		deviceMemset((*s).gridPolarizationTime1, 0, 2 * (*s).Ngrid * sizeof(deviceFP));
-		deviceMemset((*s).workspace1, 0, beamExpansionFactor * 2 * (*s).NgridC * sizeof(deviceComplex));
-		deviceMemset((*s).gridEFrequency1, 0, 2 * (*s).NgridC * sizeof(deviceComplex));
-		deviceMemset((*s).gridPropagationFactor1, 0, 2 * (*s).NgridC * sizeof(deviceComplex));
-		deviceMemset((*s).gridPolarizationFactor1, 0, 2 * (*s).NgridC * sizeof(deviceComplex));
-		deviceMemset((*s).gridEFrequency1Next1, 0, 2 * (*s).NgridC * sizeof(deviceComplex));
-		deviceMemset((*s).k1, 0, 2 * (*s).NgridC * sizeof(deviceComplex));
-
-		//cylindric sym grids
-		if ((*s).isCylindric) {
-			deviceMemset(
-				(*s).gridPropagationFactor1Rho1, 
-				0, 
-				4 * (*s).NgridC * sizeof(deviceComplex));
-			deviceMemset(
-				(*s).gridRadialLaplacian1, 
-				0, 
-				2 * beamExpansionFactor * (*s).Ngrid * sizeof(deviceComplex));
-		}
-
-		//smaller helper grids
-		deviceMemset((*s).expGammaT, 0, 2 * (*s).Ntime * sizeof(deviceFP));
-		deviceMemset((*s).chiLinear1, 0, 2 * (*s).Nfreq * sizeof(deviceComplex));
-		deviceMemset((*s).fieldFactor1, 0, 2 * (*s).Nfreq * sizeof(deviceFP));
-		deviceMemset((*s).inverseChiLinear1, 0, 2 * (*s).Nfreq * sizeof(deviceFP));
-
-		std::vector<double> expGammaTCPU(2 * (*s).Ntime);
-		for (int64_t i = 0; i < (*s).Ntime; ++i) {
-			expGammaTCPU[i] = exp((*s).dt * i * (*sCPU).drudeGamma);
-			expGammaTCPU[i + (*s).Ntime] = exp(-(*s).dt * i * (*sCPU).drudeGamma);
-		}
-		deviceMemcpy((*s).expGammaT, expGammaTCPU.data(), 2 * sizeof(double) * (*s).Ntime, copyType::ToDevice);
-
-		sCPU->finishConfiguration(s);
-		deviceMemcpy(
-			dParamsDevice, 
-			s, 
-			sizeof(deviceParameterSet<deviceFP, deviceComplex>), 
-			copyType::ToDevice);
+		allocation->useNewParameterSet(sCPU);
 	}
 	int allocateSet(simulationParameterSet* sCPU) {
 		
@@ -457,77 +310,15 @@ public:
 			}
 			
 		}
-		deviceCalloc((void**)&dParamsDevice, 1, sizeof(deviceParameterSet<deviceFP, deviceComplex>));
+
 		
 		cParams = sCPU;
-		sCPU->initializeDeviceParameters(s);
-		hasPlasma = s->hasPlasma;
+		if(memoryStatus == 0) allocation = nullptr;
+		allocation = std::make_unique<UPPEAllocation<deviceFP, deviceComplex>>(this, sCPU);
+		s = &(allocation->parameterSet);
 		fftInitialize();
-		int memErrors = 0;
+		dParamsDevice = allocation->parameterSet_deviceCopy.device_ptr();
 
-		int64_t beamExpansionFactor = 1;
-		if ((*s).isCylindric) {
-			beamExpansionFactor = 2;
-			if ((*s).hasPlasma) beamExpansionFactor = 4;
-		}
-
-		sCPU->fillRotationMatricies(s);
-		//GPU allocations
-		//
-		// currently 8 large grids, meaning memory use is approximately
-		// 64 bytes per grid point (8 grids x 2 polarizations x 4ouble precision)
-		// plus a little bit for additional constants/workspaces/etc
-		memErrors += deviceCalloc((void**)
-			&(*s).gridETime1, 2 * (*s).Ngrid, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPolarizationTime1, 2 * (*s).Ngrid, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).workspace1, beamExpansionFactor * 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridEFrequency1, 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPropagationFactor1, 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridPolarizationFactor1, 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridEFrequency1Next1, 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).k1, 2 * (*s).NgridC, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).gridBiaxialDelta, (*s).NgridC, sizeof(deviceFP));
-		//cylindric sym grids
-		if ((*s).isCylindric) {
-			memErrors += deviceCalloc((void**)
-				&(*s).gridPropagationFactor1Rho1, 4 * (*s).NgridC, sizeof(deviceComplex));
-			memErrors += deviceCalloc((void**)
-				&(*s).gridRadialLaplacian1, beamExpansionFactor * 2 * (*s).Ngrid, sizeof(deviceComplex));
-		}
-
-		//smaller helper grids
-		memErrors += deviceCalloc((void**)
-			&(*s).expGammaT, 2 * (*s).Ntime, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).chiLinear1, 2 * (*s).Nfreq, sizeof(deviceComplex));
-		memErrors += deviceCalloc((void**)
-			&(*s).fieldFactor1, 2 * (*s).Nfreq, sizeof(deviceFP));
-		memErrors += deviceCalloc((void**)
-			&(*s).inverseChiLinear1, 2 * (*s).Nfreq, sizeof(deviceFP));
-		std::vector<double> expGammaTCPU(2 * (*s).Ntime);
-		for (int64_t i = 0; i < (*s).Ntime; ++i) {
-			expGammaTCPU[i] = exp((*s).dt * i * (*sCPU).drudeGamma);
-			expGammaTCPU[i + (*s).Ntime] = exp(-(*s).dt * i * (*sCPU).drudeGamma);
-		}
-		deviceMemcpy((*s).expGammaT, expGammaTCPU.data(), 2 * sizeof(double) * (*s).Ntime, copyType::ToDevice);
-		(*sCPU).memoryError = memErrors;
-		if (memErrors > 0) {
-			return memErrors;
-		}
-		sCPU->finishConfiguration(s);
-		deviceMemcpy(
-			dParamsDevice, 
-			s, 
-			sizeof(deviceParameterSet<deviceFP, deviceComplex>), 
-			copyType::ToDevice);
 		return 0;
 	}
 };

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -1624,9 +1624,8 @@ public:
 
         QObject::connect(buttons["stop"], &QPushButton::clicked, [&](){
             if (theSim.base().isRunning) {
-                theSim.base().cancellationCalled = true;
-                for (int i = 1; i < theSim.base().Nsims; ++i) {
-                    theSim.base().cancellationCalled = true;
+                for(simulationParameterSet& sim : theSim.parameters){
+                    sim.cancellationCalled = true;
                 }
             }
         });

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -18,8 +18,8 @@ public:
     
 protected:
     void paintEvent(QPaintEvent* event) override {
-        qreal ratio = devicePixelRatioF();
-        QImage image(ratio*size(), QImage::Format_ARGB32);
+        qreal ratio = devicePixelRatio();
+        QImage image(ratio * size(), QImage::Format_ARGB32);
         image.setDevicePixelRatio(ratio);
         cairo_surface_t* surface = cairo_image_surface_create_for_data(
             image.bits(),
@@ -28,10 +28,10 @@ protected:
             image.height(),
             image.bytesPerLine());
         cairo_t* cr = cairo_create(surface);
-
+        cairo_scale(cr, ratio, ratio);
         theFunction(cr,
-            image.width(),
-            image.height(),
+            image.width()/ratio,
+            image.height()/ratio,
             theGui);
 
         cairo_destroy(cr);
@@ -2134,7 +2134,6 @@ void drawField1Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
     }
 
     int64_t cubeMiddle = theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
-    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2180,7 +2179,6 @@ void drawField2Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
     int64_t cubeMiddle = 
         theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
 
-    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2237,7 +2235,6 @@ void drawSpectrum1Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
         forceY = true;
     }
  
-    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2303,7 +2300,6 @@ void drawSpectrum2Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
         forceY = true;
     }
 
-    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -30,8 +30,8 @@ protected:
         cairo_t* cr = cairo_create(surface);
         cairo_scale(cr, ratio, ratio);
         theFunction(cr,
-            image.width()/ratio,
-            image.height()/ratio,
+            ceil(image.width()/ratio),
+            ceil(image.height()/ratio),
             theGui);
 
         cairo_destroy(cr);

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -1703,9 +1703,9 @@ public:
             appendPlot(5,0,3);
             appendPlot(6,1,2);
             appendPlot(7,1,3);
-
             SVGStrings[7].append("</svg>");
             isMakingSVG = false;
+            
             std::ofstream fs(SVGpath);
             for(std::string& str : SVGStrings){
                 fs << str;

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -2134,7 +2134,7 @@ void drawField1Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
     }
 
     int64_t cubeMiddle = theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
-
+    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2180,7 +2180,7 @@ void drawField2Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
     int64_t cubeMiddle = 
         theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
 
-
+    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2237,6 +2237,7 @@ void drawSpectrum1Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
         forceY = true;
     }
  
+    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;
@@ -2301,7 +2302,8 @@ void drawSpectrum2Plot(cairo_t* cr, int width, int height, LWEGui& theGui) {
     if (yMin != yMax && yMax > yMin) {
         forceY = true;
     }
- 
+
+    sPlot.fontSize = 14.0 * (theGui.screen()->logicalDotsPerInch() / theGui.screen()->physicalDotsPerInch());
     sPlot.makeSVG = theGui.isMakingSVG;
     sPlot.height = height;
     sPlot.width = width;

--- a/Source/Frontend/LightwaveExplorerFrontendQt.cpp
+++ b/Source/Frontend/LightwaveExplorerFrontendQt.cpp
@@ -2097,25 +2097,38 @@ void drawTimeImage1(cairo_t* cr, int width, int height, LWEGui& theGui) {
         blackoutCairoPlot(cr,width,height);
         return;
     }
-    LweImage sPlot;
-    int64_t simIndex = maxN(0,theGui.slider->value());
 
+    int64_t simIndex = maxN(0,theGui.slider->value());
     if (simIndex > theGui.theSim.base().Nsims * theGui.theSim.base().Nsims2) {
         simIndex = 0;
     }
-
     int64_t cubeMiddle = theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
 
-    sPlot.data =
-        &theGui.theSim.base().ExtOut[simIndex * theGui.theSim.base().Ngrid * 2 + cubeMiddle];
-    sPlot.dataXdim = theGui.theSim.base().Ntime;
-    sPlot.dataYdim = theGui.theSim.base().Nspace;
+    LweImage image;
+    image.data = &theGui.theSim.base().ExtOut[simIndex * theGui.theSim.base().Ngrid * 2 + cubeMiddle];
+    image.dataXdim = theGui.theSim.base().Ntime;
+    image.dataYdim = theGui.theSim.base().Nspace;
+    image.height = height;
+    image.width = width;
+    image.colorMap = 4;
+    image.dataType = 0;
+
+    LwePlot sPlot;
     sPlot.height = height;
     sPlot.width = width;
-    sPlot.colorMap = 4;
-    sPlot.dataType = 0;
-    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex), std::try_to_lock);
-    if (dataLock.owns_lock()) sPlot.imagePlot(cr);
+    sPlot.image = &image;
+    sPlot.axisColor = LweColor(0.8, 0.8, 0.8, 0);
+    sPlot.xLabel = "Time (fs)";
+    sPlot.yLabel = "x (mm)";
+    sPlot.unitY = 1e3;
+    sPlot.forcedXmax = 0.5e15 * theGui.theSim.base().Ntime * theGui.theSim.base().tStep;
+    sPlot.forcedXmin = -sPlot.forcedXmax;
+    sPlot.forcedYmin = 0.5e3 * theGui.theSim.base().spatialWidth;
+    sPlot.forcedYmax = -sPlot.forcedYmin;
+    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex),std::try_to_lock);
+    if (dataLock.owns_lock()) {
+        sPlot.plot(cr);
+    }
     else blackoutCairoPlot(cr, width, height);
 }
 
@@ -2344,7 +2357,7 @@ void drawTimeImage2(cairo_t* cr, int width, int height, LWEGui& theGui) {
         blackoutCairoPlot(cr,width,height);
         return;
     }
-    LweImage sPlot;
+
     int64_t simIndex = maxN(0,theGui.slider->value());
     if (simIndex > theGui.theSim.base().Nsims * theGui.theSim.base().Nsims2) {
         simIndex = 0;
@@ -2352,16 +2365,31 @@ void drawTimeImage2(cairo_t* cr, int width, int height, LWEGui& theGui) {
 
     int64_t cubeMiddle = theGui.theSim.base().Ntime * theGui.theSim.base().Nspace * (theGui.theSim.base().Nspace2 / 2);
 
-    sPlot.data =
-    &theGui.theSim.base().ExtOut[theGui.theSim.base().Ngrid + simIndex * theGui.theSim.base().Ngrid * 2 + cubeMiddle];
-    sPlot.dataYdim = theGui.theSim.base().Nspace;
-    sPlot.dataXdim = theGui.theSim.base().Ntime;
+    LweImage image;
+    image.data = &theGui.theSim.base().ExtOut[simIndex * theGui.theSim.base().Ngrid * 2 + theGui.theSim.base().Ngrid + cubeMiddle];
+    image.dataXdim = theGui.theSim.base().Ntime;
+    image.dataYdim = theGui.theSim.base().Nspace;
+    image.height = height;
+    image.width = width;
+    image.colorMap = 4;
+    image.dataType = 0;
+
+    LwePlot sPlot;
     sPlot.height = height;
     sPlot.width = width;
-    sPlot.colorMap = 4;
-    sPlot.dataType = 0;
-    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex), std::try_to_lock);
-    if (dataLock.owns_lock()) sPlot.imagePlot(cr);
+    sPlot.image = &image;
+    sPlot.axisColor = LweColor(0.8, 0.8, 0.8, 0);
+    sPlot.xLabel = "Time (fs)";
+    sPlot.yLabel = "x (mm)";
+    sPlot.unitY = 1e3;
+    sPlot.forcedXmax = 0.5e15 * theGui.theSim.base().Ntime * theGui.theSim.base().tStep;
+    sPlot.forcedXmin = -sPlot.forcedXmax;
+    sPlot.forcedYmin = 0.5e3 * theGui.theSim.base().spatialWidth;
+    sPlot.forcedYmax = -sPlot.forcedYmin;
+    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex),std::try_to_lock);
+    if (dataLock.owns_lock()) {
+        sPlot.plot(cr);
+    }
     else blackoutCairoPlot(cr, width, height);
 }
 
@@ -2371,7 +2399,7 @@ void drawFourierImage1(cairo_t* cr, int width, int height, LWEGui& theGui) {
         blackoutCairoPlot(cr,width,height);
         return;
     }
-    LweImage sPlot;
+    LweImage image;
     int64_t simIndex = maxN(0,theGui.slider->value());
     if (simIndex > theGui.theSim.base().Nsims * theGui.theSim.base().Nsims2) {
         simIndex = 0;
@@ -2382,18 +2410,35 @@ void drawFourierImage1(cairo_t* cr, int width, int height, LWEGui& theGui) {
             (double)(1e-4 
                 / (theGui.theSim.base().spatialWidth * theGui.theSim.base().spatialHeight * theGui.theSim.base().timeSpan));
     }
-    sPlot.complexData =
+    image.complexData =
         &theGui.theSim.base().EkwOut[simIndex * theGui.theSim.base().NgridC * 2];
-    sPlot.dataXdim = theGui.theSim.base().Nfreq;
-    sPlot.dataYdim = theGui.theSim.base().Nspace;
+
+    image.dataXdim = theGui.theSim.base().Nfreq;
+    image.dataYdim = theGui.theSim.base().Nspace;
+    image.height = height;
+    image.width = width;
+    image.colorMap = 3;
+    image.dataType = 1;
+    image.logMin = logPlotOffset;
+    LwePlot sPlot;
     sPlot.height = height;
     sPlot.width = width;
-    sPlot.dataType = 1;
-    sPlot.colorMap = 3;
-    sPlot.logMin = logPlotOffset;
-    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex), std::try_to_lock);
-    if (dataLock.owns_lock()) sPlot.imagePlot(cr);
+    sPlot.image = &image;
+    sPlot.axisColor = LweColor(0.8, 0.8, 0.8, 0);
+    sPlot.xLabel = "Frequency (THz)";
+    sPlot.yLabel = "Transverse k (1/\xce\xbcm)";
+    sPlot.unitY = 1;
+    sPlot.forcedXmax = 1e-12*(theGui.theSim.base().Nfreq-1) * theGui.theSim.base().fStep;
+    sPlot.forcedXmin = 0;
+    sPlot.forcedYmin = -0.5e-6 * theGui.theSim.base().Nspace * theGui.theSim.base().kStep;
+    sPlot.forcedYmax = -sPlot.forcedYmin;
+    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex),std::try_to_lock);
+    if (dataLock.owns_lock()) {
+        sPlot.plot(cr);
+    }
     else blackoutCairoPlot(cr, width, height);
+
+    
 }
 
 void drawFourierImage2(cairo_t* cr, int width, int height, LWEGui& theGui) {
@@ -2402,7 +2447,7 @@ void drawFourierImage2(cairo_t* cr, int width, int height, LWEGui& theGui) {
         blackoutCairoPlot(cr,width,height);
         return;
     }
-    LweImage sPlot;
+    LweImage image;
 
     int64_t simIndex = maxN(0,theGui.slider->value());
     if (simIndex > theGui.theSim.base().Nsims * theGui.theSim.base().Nsims2) {
@@ -2414,17 +2459,31 @@ void drawFourierImage2(cairo_t* cr, int width, int height, LWEGui& theGui) {
         logPlotOffset = (double)(1e-4 
             / (theGui.theSim.base().spatialWidth * theGui.theSim.base().spatialHeight * theGui.theSim.base().timeSpan));
     }
-    sPlot.complexData =
+    image.complexData =
         &theGui.theSim.base().EkwOut[simIndex * theGui.theSim.base().NgridC * 2 + theGui.theSim.base().NgridC];
-    sPlot.dataXdim = theGui.theSim.base().Nfreq;
-    sPlot.dataYdim = theGui.theSim.base().Nspace;
+    image.dataXdim = theGui.theSim.base().Nfreq;
+    image.dataYdim = theGui.theSim.base().Nspace;
+    image.height = height;
+    image.width = width;
+    image.colorMap = 3;
+    image.dataType = 1;
+    image.logMin = logPlotOffset;
+    LwePlot sPlot;
     sPlot.height = height;
     sPlot.width = width;
-    sPlot.colorMap = 3;
-    sPlot.dataType = 1;
-    sPlot.logMin = logPlotOffset;
-    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex), std::try_to_lock);
-    if (dataLock.owns_lock()) sPlot.imagePlot(cr);
+    sPlot.image = &image;
+    sPlot.axisColor = LweColor(0.8, 0.8, 0.8, 0);
+    sPlot.xLabel = "Frequency (THz)";
+    sPlot.yLabel = "Transverse k (1/\xce\xbcm)";
+    sPlot.unitY = 1;
+    sPlot.forcedXmax = 1e-12*(theGui.theSim.base().Nfreq-1) * theGui.theSim.base().fStep;
+    sPlot.forcedXmin = 0;
+    sPlot.forcedYmin = -0.5e-6 * theGui.theSim.base().Nspace * theGui.theSim.base().kStep;
+    sPlot.forcedYmax = -sPlot.forcedYmin;
+    std::unique_lock dataLock(theGui.theSim.mutexes.at(simIndex),std::try_to_lock);
+    if (dataLock.owns_lock()) {
+        sPlot.plot(cr);
+    }
     else blackoutCairoPlot(cr, width, height);
 }
 

--- a/Source/Frontend/LightwaveExplorerPlots.h
+++ b/Source/Frontend/LightwaveExplorerPlots.h
@@ -174,9 +174,9 @@ public:
         //Fixed parameters affecting aesthetics
         double radius = 2;
         double lineWidth = 1.5;
-        double axisSpaceX = 75.0;
-        double axisSpaceY = 35.0;
-        double axisLabelSpaceX = 21.0;
+        double axisSpaceX = 5.36 * fontSize;
+        double axisSpaceY = 2.5 * fontSize;
+        double axisLabelSpaceX = 1.5 * fontSize;
 
         //get limits and make the plotting arrays
         double maxY = -1.0e300;

--- a/Source/Frontend/LightwaveExplorerPlots.h
+++ b/Source/Frontend/LightwaveExplorerPlots.h
@@ -582,8 +582,8 @@ public:
                 SVGString.append(imagePNG);
             }   
         }
-        double scaleX = width / ((double)(maxX - minX));
-        double scaleY = height / ((double)(maxY - minY));
+        double scaleX = width / (maxX - minX);
+        double scaleY = height / (maxY - minY);
         LweColor currentColor = textColor;
         currentColor = textColor;
 

--- a/Source/Frontend/LightwaveExplorerPlots.h
+++ b/Source/Frontend/LightwaveExplorerPlots.h
@@ -118,6 +118,7 @@ public:
     bool markers = true;
     double width = 0;
     double height = 0;
+    double fontSize = 14.0;
     double* data = nullptr;
     int ExtraLines = 0;
     double* data2 = nullptr;
@@ -160,7 +161,6 @@ public:
         int64_t iMax = Npts;
         cairo_font_extents_t fe{};
         cairo_text_extents_t te{};
-        double fontSize = 14.0;
         cairo_set_font_size(cr, fontSize);
         cairo_select_font_face(cr, "Arial", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
         cairo_font_extents(cr, &fe);

--- a/Source/Frontend/LightwaveExplorerPlots.h
+++ b/Source/Frontend/LightwaveExplorerPlots.h
@@ -700,7 +700,7 @@ public:
             else {
                 messageBuffer = Sformat("{:4.4f}", ytVal);
             }
-
+            if(messageBuffer=="0.0e+00") messageBuffer = "0";
             layoutLeft = axisLabelSpaceX;
             layoutTop = (i * (0.5 * (height)));
             if (i == 2) layoutTop -= 8.0f;
@@ -744,6 +744,7 @@ public:
         //x-axis tick labels
         for (int i = 0; i < 3; ++i) {
             messageBuffer.assign(Sformat("{}", (int)round(xTicks1[i])));
+            if(messageBuffer=="0.0e+00") messageBuffer = "0";
             layoutLeft = axisSpaceX + 0.25 * width * ((int64_t)(i)+1) - 0.5 * axisSpaceX;
             layoutTop = height + 3;
             layoutBottom = height + axisSpaceY;

--- a/Source/Kernels.hpp
+++ b/Source/Kernels.hpp
@@ -1340,7 +1340,7 @@ namespace kernelNamespace{
 		deviceFunction void operator()(const int64_t i) const {
 			const int64_t j = (i) * (*s).Ntime;
 			const deviceFP* expMinusGammaT = &(*s).expGammaT[(*s).Ntime];
-			const deviceFP* dN = j + reinterpret_cast<deviceFP*>((*s).workspace1);
+			const deviceFP* dN = (j % (*s).Ngrid) + reinterpret_cast<deviceFP*>((*s).workspace1);
 			const deviceFP* E = &(*s).gridETime1[j];
 			deviceFP* P = &(*s).gridPolarizationTime1[j];
 			SimpsonIntegrator<deviceFP> N(s->plasmaParameters.initialDensity);

--- a/Source/LightwaveExplorerInterfaceClasses.cpp
+++ b/Source/LightwaveExplorerInterfaceClasses.cpp
@@ -864,6 +864,7 @@ void simulationBatch::configure(bool allocateFields) {
 			parameters[j + currentRow].EkwOut = getEkw((j + currentRow));
 			parameters[j + currentRow].totalSpectrum = getTotalSpectrum((j + currentRow));
 			parameters[j + currentRow].isFollowerInSequence = false;
+			parameters[j + currentRow].cancellationCalled = false;
 			parameters[j + currentRow].setByNumberWithMultiplier(
 				parameters[0].batchIndex, 
 				parameters[0].getByNumberWithMultiplier(

--- a/Source/LightwaveExplorerInterfaceClasses.hpp
+++ b/Source/LightwaveExplorerInterfaceClasses.hpp
@@ -520,16 +520,15 @@ struct UPPEAllocation{
     LWEBuffer<deviceComplex> gridEFrequency;
     LWEBuffer<deviceComplex> gridEFrequencyNext;
     LWEBuffer<deviceComplex> gridPropagationFactor;
+    LWEBuffer<deviceComplex> gridPolarizationFactor;
+    LWEBuffer<deviceFP> gridBiaxialDelta;
     LWEBuffer<deviceComplex> gridPropagationFactorRho;
     LWEBuffer<deviceFP> gridRadialLaplacian;
-    LWEBuffer<deviceComplex> gridPolarizationFactor;
     LWEBuffer<deviceComplex> k;
-    LWEBuffer<deviceFP> gridBiaxialDelta;
     LWEBuffer<deviceComplex> chiLinear;
     LWEBuffer<deviceFP> inverseChiLinear;
     LWEBuffer<deviceFP> fieldFactor;
     LWEBuffer<deviceFP> expGammaT;
-
     deviceParameterSet<deviceFP, deviceComplex> parameterSet;
     LWEBuffer<deviceParameterSet<deviceFP, deviceComplex>> parameterSet_deviceCopy;
     

--- a/Source/LightwaveExplorerInterfaceClasses.hpp
+++ b/Source/LightwaveExplorerInterfaceClasses.hpp
@@ -240,6 +240,10 @@ public:
         if (index == 0 || index == 36 || index >= multipliers.size()) return 0.0;
         return  getByNumber(index) / multipliers[index];
     }
+
+    [[nodiscard]] constexpr bool hasPlasma() const {
+        return nonlinearAbsorptionStrength > 0.0 || startingCarrierDensity > 0.0;
+    }
     
     constexpr double getByNumber(const std::size_t index) {
         switch (index) {

--- a/Source/LightwaveExplorerInterfaceClasses.hpp
+++ b/Source/LightwaveExplorerInterfaceClasses.hpp
@@ -591,6 +591,23 @@ struct UPPEAllocation{
         sCPU->finishConfiguration(&parameterSet);
         d->deviceMemcpy(parameterSet_deviceCopy.device_ptr(), &parameterSet, sizeof(deviceParameterSet<deviceFP, deviceComplex>), copyType::ToDevice);
     }
+
+    void zero_initialize_grids(){
+        workspace.initialize_to_zero();
+        gridETime.initialize_to_zero();
+        gridPolarizationTime.initialize_to_zero();
+        gridEFrequency.initialize_to_zero();
+        gridEFrequencyNext.initialize_to_zero();
+        gridPropagationFactor.initialize_to_zero();
+        gridPropagationFactorRho.initialize_to_zero();
+        gridPolarizationFactor.initialize_to_zero();
+        gridBiaxialDelta.initialize_to_zero();
+        gridRadialLaplacian.initialize_to_zero();
+        k.initialize_to_zero();
+        chiLinear.initialize_to_zero();
+        inverseChiLinear.initialize_to_zero();
+        fieldFactor.initialize_to_zero();
+    }
 };
 
 

--- a/Source/LightwaveExplorerInterfaceClasses.hpp
+++ b/Source/LightwaveExplorerInterfaceClasses.hpp
@@ -503,6 +503,98 @@ public:
     }
 };
 
+
+template <typename deviceFP, typename deviceComplex>
+struct UPPEAllocation{
+    bool hasPlasma = false;
+    bool isCylindric = false;
+    int64_t beamExpansionFactor = 1;
+    int64_t Ngrid = 0;
+    int64_t Ntime = 0;
+    int64_t Nfreq = 0;
+    int64_t Ngrid_complex = 0;
+
+    LWEBuffer<deviceComplex> workspace;
+    LWEBuffer<deviceFP> gridETime;
+    LWEBuffer<deviceFP> gridPolarizationTime;
+    LWEBuffer<deviceComplex> gridEFrequency;
+    LWEBuffer<deviceComplex> gridEFrequencyNext;
+    LWEBuffer<deviceComplex> gridPropagationFactor;
+    LWEBuffer<deviceComplex> gridPropagationFactorRho;
+    LWEBuffer<deviceFP> gridRadialLaplacian;
+    LWEBuffer<deviceComplex> gridPolarizationFactor;
+    LWEBuffer<deviceComplex> k;
+    LWEBuffer<deviceFP> gridBiaxialDelta;
+    LWEBuffer<deviceComplex> chiLinear;
+    LWEBuffer<deviceFP> inverseChiLinear;
+    LWEBuffer<deviceFP> fieldFactor;
+    LWEBuffer<deviceFP> expGammaT;
+
+    deviceParameterSet<deviceFP, deviceComplex> parameterSet;
+    LWEBuffer<deviceParameterSet<deviceFP, deviceComplex>> parameterSet_deviceCopy;
+    
+    UPPEAllocation(){}
+
+    UPPEAllocation(LWEDevice* d, simulationParameterSet* sCPU) : 
+    hasPlasma(sCPU->nonlinearAbsorptionStrength > 0.0 || sCPU->startingCarrierDensity > 0.0),
+    isCylindric(sCPU->isCylindric),
+    beamExpansionFactor(1 + isCylindric + 2 * isCylindric * hasPlasma),
+    Ngrid(sCPU->Ngrid),
+    Ntime(sCPU->Ntime),
+    Nfreq(sCPU->Nfreq),
+    Ngrid_complex(sCPU->NgridC),
+    workspace(d, beamExpansionFactor * 2 * Ngrid_complex, sizeof(deviceComplex)),
+    gridETime(d, 2 * Ngrid, sizeof(deviceFP)),
+    gridPolarizationTime(d, 2 * Ngrid, sizeof(deviceFP)),
+    gridEFrequency(d, 2 * Ngrid_complex, sizeof(deviceComplex)),
+    gridEFrequencyNext(d, 2 * Ngrid_complex, sizeof(deviceComplex)),
+    gridPropagationFactor(d, 2 * Ngrid_complex, sizeof(deviceComplex)),
+    gridPolarizationFactor(d, 2 * Ngrid_complex, sizeof(deviceComplex)),
+    gridBiaxialDelta(d, Ngrid_complex, sizeof(deviceComplex)),
+    gridPropagationFactorRho(d, isCylindric * 4 * Ngrid_complex, sizeof(deviceComplex)),
+    gridRadialLaplacian(d, isCylindric * beamExpansionFactor * 2 * Ngrid, sizeof(deviceComplex)),
+    k(d, 2 *Ngrid_complex, sizeof(deviceComplex)),
+    chiLinear(d, 2 * Nfreq, sizeof(deviceComplex)),
+    inverseChiLinear(d, 2 * Nfreq, sizeof(deviceFP)),
+    fieldFactor(d, 2 * Nfreq, sizeof(deviceFP)),
+    expGammaT(d, 2 * Ntime, sizeof(double)),
+    parameterSet_deviceCopy(d, 1, sizeof(deviceParameterSet<deviceFP, deviceComplex>))
+    {
+        sCPU->initializeDeviceParameters(&parameterSet);
+        parameterSet.workspace1 = workspace.device_ptr();
+        parameterSet.gridETime1 = gridETime.device_ptr();
+        parameterSet.gridPolarizationTime1 = gridPolarizationTime.device_ptr();
+        parameterSet.gridEFrequency1 = gridEFrequency.device_ptr();
+        parameterSet.gridEFrequency1Next1 = gridEFrequencyNext.device_ptr();
+        parameterSet.gridPropagationFactor1 = gridPropagationFactor.device_ptr();
+        parameterSet.gridPolarizationFactor1 = gridPolarizationFactor.device_ptr();
+        parameterSet.gridBiaxialDelta = gridBiaxialDelta.device_ptr();
+        parameterSet.gridPropagationFactor1Rho1 = gridPropagationFactorRho.device_ptr();
+        parameterSet.gridRadialLaplacian1 = gridRadialLaplacian.device_ptr();
+        parameterSet.k1 = k.device_ptr();
+        parameterSet.chiLinear1 = chiLinear.device_ptr();
+        parameterSet.inverseChiLinear1 = inverseChiLinear.device_ptr();
+        parameterSet.fieldFactor1 = fieldFactor.device_ptr();
+        parameterSet.expGammaT = expGammaT.device_ptr();
+
+        sCPU->fillRotationMatricies(&parameterSet);
+
+
+        std::vector<deviceFP> expGammaTCPU(2 * Ntime);
+		for (int64_t i = 0; i < Ntime; ++i) {
+			expGammaTCPU[i] = static_cast<deviceFP>(exp(sCPU->tStep * i * sCPU->drudeGamma));
+			expGammaTCPU[i + sCPU->Ntime] = static_cast<deviceFP>(exp(-sCPU->tStep * i * sCPU->drudeGamma));
+		}
+        d->deviceMemcpy(expGammaT.device_ptr(), expGammaTCPU.data(), 2 * sizeof(deviceFP) * Ntime, copyType::ToDevice);
+        
+        
+        sCPU->finishConfiguration(&parameterSet);
+        d->deviceMemcpy(parameterSet_deviceCopy.device_ptr(), &parameterSet, sizeof(deviceParameterSet<deviceFP, deviceComplex>), copyType::ToDevice);
+    }
+};
+
+
+
 int				loadFrogSpeck(const loadedInputData& frogFilePath, std::complex<double>* Egrid, const int64_t Ntime, const double fStep, const double gateLevel);
 int             loadWaveformFile(const loadedInputData& waveformFile, std::complex<double>* outputGrid, const int64_t Ntime, const double fStep);
 int             loadSavedGridFile(const loadedInputData& file, std::vector<double>& outputGrid, int64_t Ngrid);


### PR DESCRIPTION
Fix the bug introduced in 2025.0 where the effect of plasma on y-polarized field was ignored on CUDA
Add scales and axes to the space/time and momentum/frequency images, include them in saved SVG files
Fix batch cancellation bug
Refactor devices to use a LWEDevice class as a base, which performs a lot of the common operations, and make a UPPEAllocation class which contains new LWEBuffer classes to handle allocations in a cross-arch RAII way.